### PR TITLE
[FEAT] More dynamic options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Other options are available to extends log level details ([odoo-sentry-sample.co
 You can also set other Raven options by defining `sentry_options_<option here>`, eg. `sentry_options_environment = production` 
 will tell Sentry the event came from the production environment.
 
+Additionally, you can set some default context values and tags using `sentry_context_<context here>` or `sentry_context_tags_<tag key here>`. For example `sentry_context_tags_build = 20170516` would send the tag `build` with the value `20170516`.
+
 ### License
 This project is licensed under [AGPL v3](http://www.gnu.org/licenses/agpl-3.0.html).
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Other options are available to extends log level details ([odoo-sentry-sample.co
 - `sentry_allow_orm_warning`: *default `false`*. enabling this will capture Odoo's warning exceptions (e.g. `except_osv`, `openerp.exceptions.Warning`).
 - `sentry_include_context`: *default `false`*. this will add details about the odoo user that triggers specific event, plus database name, will displayed in Sentry additional info.
 - `sentry_error_level`: *default `warning`*. select the minimum logging level that should be propagated to Sentry.
+- `sentry_release`: *defaults to Odoo version`*. define your project's release here.
+
+You can also set other Raven options by defining `sentry_options_<option here>`, eg. `sentry_options_environment = production` 
+will tell Sentry the event came from the production environment.
 
 ### License
 This project is licensed under [AGPL v3](http://www.gnu.org/licenses/agpl-3.0.html).

--- a/__init__.py
+++ b/__init__.py
@@ -47,7 +47,7 @@ INCLUDE_USER_CONTEXT = config.get('sentry_include_context', False)
 ERROR_LEVEL = config.get('sentry_error_level', 'WARNING')
 ODOO_MAJOR_VERSION = odoo.release.major_version
 ODOO_VERSION = odoo.release.version
-RELEASE = config.get('sentry_release', ODOO_VERSION)
+RELEASE = config.get('sentry_release', False)
 
 
 def get_user_context():
@@ -97,7 +97,7 @@ class ContextSentryHandler(SentryHandler):
         super(ContextSentryHandler, self).emit(rec)
 
 # Get default context and tags from the Odoo configuration
-tags = dict(odoo_major_version=ODOO_MAJOR_VERSION)
+tags = dict(odoo_major_version=ODOO_MAJOR_VERSION, odoo_version=ODOO_VERSION)
 context = dict()
 for key, value in config.options.iteritems():
     if key.startswith('sentry_context_tags_'):
@@ -105,8 +105,6 @@ for key, value in config.options.iteritems():
         continue
     elif key.startswith('sentry_context_'):
         context[key.replace('sentry_context_', '')] = value
-context = dict(context, tags=tags)
-context['odoo_version'] = ODOO_VERSION
 
 # Get options from the Odoo configuration
 options = {key.replace('sentry_options_', ''): value
@@ -115,6 +113,7 @@ options = {key.replace('sentry_options_', ''): value
 if RELEASE:
     options['release'] = RELEASE
 options['context'] = context
+options['tags'] = tags
 
 client = Client(CLIENT_DSN, **options)
 

--- a/__init__.py
+++ b/__init__.py
@@ -45,6 +45,7 @@ ENABLE_LOGGING = config.get('sentry_enable_logging', False)
 ALLOW_ORM_WARNING = config.get('sentry_allow_orm_warning', False)
 INCLUDE_USER_CONTEXT = config.get('sentry_include_context', False)
 ERROR_LEVEL = config.get('sentry_error_level', 'WARNING')
+ODOO_MAJOR_VERSION = odoo.release.major_version
 ODOO_VERSION = odoo.release.version
 RELEASE = config.get('sentry_release', ODOO_VERSION)
 
@@ -95,10 +96,16 @@ class ContextSentryHandler(SentryHandler):
             client.extra_context(get_user_context())
         super(ContextSentryHandler, self).emit(rec)
 
-# Get default context from the Odoo configuration
-context = {key.replace('sentry_context_', ''): value
-           for key, value in config.options.iteritems()
-           if key.startswith('sentry_context_')}
+# Get default context and tags from the Odoo configuration
+tags = dict(odoo_major_version=ODOO_MAJOR_VERSION)
+context = dict()
+for key, value in config.options.iteritems():
+    if key.startswith('sentry_context_tags_'):
+        tags[key.replace('sentry_context_tags_', '')] = value
+        continue
+    elif key.startswith('sentry_context_'):
+        context[key.replace('sentry_context_', '')] = value
+context = dict(context, tags=tags)
 context['odoo_version'] = ODOO_VERSION
 
 # Get options from the Odoo configuration

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -22,8 +22,8 @@
 
 {
     'name': 'Odoo Sentry connector',
-    'version': '1.0',
-    'author': 'Mohammed Barsi',
+    'version': '1.1.0',
+    'author': 'Mohammed Barsi, Avoin.Systems',
     'sequence': 4,
     'summary': 'Exceptions tracker',
     'description':

--- a/odoo-sentry-sample.conf
+++ b/odoo-sentry-sample.conf
@@ -8,3 +8,8 @@ sentry_enable_logging = true
 sentry_allow_orm_warning = true
 # user context, login name, uid, dbname, etc
 sentry_include_context = true
+# Project release
+sentry_release = 10.0.1.2.3
+# Tags are given in the context as separate paramters
+sentry_context_tags_build = 20170516
+sentry_context_tags_foo = bar


### PR DESCRIPTION
- Define the release by using the `sentry_release` configuration parameter
- Support defining arbitrary options by using `sentry_options_`
  configuration parameter prefix